### PR TITLE
fix some Ubuntu 22.04 AMIs and add ROS2 Humble support

### DIFF
--- a/c9-ros-nice-cfn.yaml
+++ b/c9-ros-nice-cfn.yaml
@@ -25,8 +25,9 @@ Parameters:
       - ROS1Melodic
       - NoROSUbuntu1804
       - ROS1Noetic
-      - NoROSUbuntu2004
       - ROS2Foxy
+      - NoROSUbuntu2004
+      - ROS2Humble
       - NoROSUbuntu2204
   Simulator:
     Description: Simulator to install
@@ -48,6 +49,8 @@ Mappings:
       Ubuntu: Ubuntu2004
     ROS2Foxy:
       Ubuntu: Ubuntu2004
+    ROS2Humble:
+      Ubuntu: Ubuntu2204
     NoROSUbuntu1804:
       Ubuntu: Ubuntu1804
     NoROSUbuntu2004:
@@ -89,14 +92,14 @@ Mappings:
       Ubuntu1804GPU: ami-003566b22128092cd # isaacsim: ami-08084538a6dec4734
       Ubuntu2004CPU: ami-08d4ac5b634553e16 # Ubuntu Server 20.04 LTS (HVM), SSD Volume Type
       Ubuntu2004GPU: ami-08cb7e65c4e13f22d # Deep Learning AMI GPU PyTorch 1.12.0 (Ubuntu 20.04) 20220824
-      Ubuntu2204CPU: ami-099bc67a2500003c1 # Cloud9Ubuntu-2022-04-28T13-38
+      Ubuntu2204CPU: ami-007855ac798b5175e # Ubuntu Server 22.04 LTS (HVM), SSD Volume Type
       #Ubuntu2204GPU: TODO # Deep Learning AMI GPU PyTorch ? (Ubuntu 22.04)
     us-west-2:
       Ubuntu1804CPU: ami-0cfa91bdbc3be780c # Ubuntu Server 18.04 LTS (HVM), SSD Volume Type
       Ubuntu1804GPU: ami-0475f1fb0e9b1f73f # isaacsim: ami-08084538a6dec4734
       Ubuntu2004CPU: ami-0ddf424f81ddb0720 # Ubuntu Server 20.04 LTS (HVM), SSD Volume Type
       Ubuntu2004GPU: ami-0eaff0d700233c573 # Deep Learning AMI GPU PyTorch 1.12.0 (Ubuntu 20.04) 20220824
-      Ubuntu2204CPU: ami-043211bbba49eb3d6 # Cloud9Ubuntu-2022-04-28T13-38
+      Ubuntu2204CPU: ami-0fcf52bcf5db7b003 # Ubuntu Server 22.04 LTS (HVM), SSD Volume Type
       #Ubuntu2204GPU: TODO # Deep Learning AMI GPU PyTorch ? (Ubuntu 22.04)
     ap-northeast-1:
       Ubuntu1804CPU: ami-021117b0e6a499966 # bionic 18.04 LTS amd64 hvm:ebs-ssd 20221201
@@ -131,7 +134,7 @@ Mappings:
       Ubuntu1804GPU: ami-0cadf512ea43b3aef # IsaacSim-Ubuntu-18.04-GPU-2022-05-31
       Ubuntu2004CPU: ami-0ab9357b9799530ef # focal 20.04 LTS amd64 hvm:ebs-ssd 20221206   hvm
       Ubuntu2004GPU: ami-03b026e61b4a8200d # Deep Learning AMI GPU PyTorch 1.13.1 (Ubuntu 20.04) 20230215
-      Ubuntu2204CPU: ami-06fa03ed767ea76ed # Cloud9Ubuntu-2022-04-28T13-38
+      Ubuntu2204CPU: ami-0310483fb2b488153 # Ubuntu Server 22.04 LTS (HVM), SSD Volume Type
       #Ubuntu2204GPU: TODO # Deep Learning AMI GPU PyTorch ? (Ubuntu 22.04)
     ap-southeast-3:
       Ubuntu1804CPU: ami-02c68bc8e70dcf83f # bionic  18.04 LTS amd64 hvm:ebs-ssd 20221201   hvm

--- a/install-ros.sh
+++ b/install-ros.sh
@@ -18,12 +18,22 @@ sudo su -l ubuntu -c "sudo rosdep init"
 sudo su -l ubuntu -c "rosdep update"
 echo "[[ -e /opt/ros/noetic/setup.bash ]] && source /opt/ros/noetic/setup.bash" >> /home/ubuntu/.bashrc
 elif [ ${ROSVERSION} == "ROS2Foxy" ]; then
-sudo apt update && sudo apt install curl gnupg2 lsb-release
+echo Installing ROS2 Foxy
+sudo apt update && sudo apt install curl gnupg2 lsb-release -y
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 sudo apt update
 sudo apt install -y ros-foxy-desktop
 echo "[[ -e /opt/ros/foxy/setup.bash ]] && source /opt/ros/foxy/setup.bash" >> /home/ubuntu/.bashrc
+elif [ ${ROSVERSION} == "ROS2Humble" ]; then
+echo Installing ROS2 Humble
+sudo apt update && sudo apt install curl gnupg2 lsb-release -y
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+sudo apt update
+sudo apt install -y ros-humble-desktop python3-colcon-common-extensions
+echo "[[ -e /opt/ros/humble/setup.bash ]] && source /opt/ros/humble/setup.bash" >> /home/ubuntu/.bashrc
+echo "[[ -e /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash ]] && source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> /home/ubuntu/.bashrc
 else
 echo "No ROS"
 fi


### PR DESCRIPTION
Update and test the Ubuntu 22.04 AMI for us-east-1, us-west-2 and ap-southeast-2
Add ROS2 Humble option for Ubuntu 22.04

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.